### PR TITLE
fix: use startline if endline is null

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -33,6 +33,6 @@ if [ $namespaces ]; then
 fi
 
 trivy $TRIVY_ARGS . \
-  | jq '.runs[].results[] | "\(.level[0:1]):\(.locations[].physicalLocation.artifactLocation.uri):\(.locations[].physicalLocation.region.endLine) \(.message.text)"' \
+  | jq '.runs[].results[]| if .locations[].physicalLocation.region.endLine then .line=.locations[].physicalLocation.region.endLine else .line=.locations[].physicalLocation.region.startLine end | "\(.level[0:1]):\(.locations[].physicalLocation.artifactLocation.uri):\(.line) \(.message.text)"' \
   | sed "s/\\\\n/<br>/g" \
   | reviewdog -efm="\"%t:%f:%l %m\"" --diff="git diff ${GITHUB_REF}" -reporter=github-pr-review


### PR DESCRIPTION
`.locations[].physicalLocation.region.endLine` of the scan result may be null as follows
```
        {
          "ruleId": "DS002",
          "ruleIndex": 18,
          "level": "error",
          "message": {
            "text": "Artifact: tools/images/github-cli/Dockerfile\nType: dockerfile\nVulnerability DS002\nSeverity: HIGH\nMessage: Specify at least 1 USER command in Dockerfile with non-root user as argument\nLink: [DS002](https://avd.aquasec.com/misconfig/ds002)"
          },
          "locations": [
            {
              "physicalLocation": {
                "artifactLocation": {
                  "uri": "tools/images/github-cli/Dockerfile",
                  "uriBaseId": "ROOTPATH"
                },
                "region": {
                  "startLine": 1
                }
              }
            }
          ]
        },
```
```
"e:Dockerfile:null Artifact: Dockerfile<br>Type: dockerfile<br>Vulnerability DS002<br>Severity: HIGH<br>Message: Specify at least 1 USER command in Dockerfile with non-root user as argument<br>Link: [DS002](https://avd.aquasec.com/misconfig/ds002)"
```

If it is null, reviewdog cannot add a comment. So, if endline is null, use startline instead