### PR TITLE
Fix: Corrected text formatting

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -33,6 +33,6 @@ if [ $namespaces ]; then
 fi
 
 trivy $TRIVY_ARGS . \
-  | jq '.runs[].results[]| if .locations[].physicalLocation.region.endLine then . else .locations[].physicalLocation.region.endLine=.locations[].physicalLocation.region.startLine end | "\(.level[0:1]):\(.locations[].physicalLocation.artifactLocation.uri):\(.locations[].physicalLocation.region.startLine):.\(.locations[].physicalLocation.region.endLine) \(.message.text)"' \
+  | jq '.runs[].results[]| if .locations[].physicalLocation.region.endLine then . else .locations[].physicalLocation.region.endLine=.locations[].physicalLocation.region.startLine end | "\(.level[0:1]):\(.locations[].physicalLocation.artifactLocation.uri):\(.locations[].physicalLocation.region.startLine):\(.locations[].physicalLocation.region.endLine) \(.message.text)"' \
   | sed "s/\\\\n/<br>/g" \
   | reviewdog -efm="\"%t:%f:%l:%e %m\"" --diff="git diff -U1000 ${GITHUB_REF}" -reporter=github-pr-review

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -33,6 +33,6 @@ if [ $namespaces ]; then
 fi
 
 trivy $TRIVY_ARGS . \
-  | jq '.runs[].results[]| if .locations[].physicalLocation.region.endLine then .line=.locations[].physicalLocation.region.endLine else .line=.locations[].physicalLocation.region.startLine end | "\(.level[0:1]):\(.locations[].physicalLocation.artifactLocation.uri):\(.line) \(.message.text)"' \
+  | jq '.runs[].results[]| if .locations[].physicalLocation.region.endLine then . else .locations[].physicalLocation.region.endLine=.locations[].physicalLocation.region.startLine end | "\(.level[0:1]):\(.locations[].physicalLocation.artifactLocation.uri):\(.locations[].physicalLocation.region.startLine):.\(.locations[].physicalLocation.region.endLine) \(.message.text)"' \
   | sed "s/\\\\n/<br>/g" \
   | reviewdog -efm="\"%t:%f:%l:%e %m\"" --diff="git diff -U1000 ${GITHUB_REF}" -reporter=github-pr-review


### PR DESCRIPTION
fix: https://github.com/security-actions/trivy-misconf-scan/pull/1

I'm correcting https://github.com/security-actions/trivy-misconf-scan/pull/1 as it was not a correction based on v1.1.
If endLine does not exist, startLine is used.